### PR TITLE
#29 Load contentScript on netflix.com and show react app only when window is on a video player page

### DIFF
--- a/src/contentScript/component/App.tsx
+++ b/src/contentScript/component/App.tsx
@@ -1,12 +1,31 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchUserPreferences } from './store/userSlice';
 import { RootState, StoreDispatch } from './store/store';
 import InitialLanguageSelectModal from '@/src/contentScript/component/components/InitialLanguageSelectModal';
+import { determineIfWindowOnPlayerPage } from '@/src/pageScript/spyOnPageUrl';
+import { setIsWindowOnPlayerPage } from '@/src/contentScript/component/store/appSlice';
 
 const App = () => {
     const dispatch = useDispatch<StoreDispatch>();
     const userState = useSelector((state: RootState) => state.user);
+    const isWindowOnPlayerPage = useSelector(
+        (state: RootState) => state.app.isWindowOnPlayerPage
+    );
+
+    // When App is loaded firs time, we should check if the window is on videoPlayer page or not.
+    useEffect(() => {
+        const currentUrl = window.location.href;
+        dispatch(
+            setIsWindowOnPlayerPage({
+                isWindowOnPlayerPage: determineIfWindowOnPlayerPage(currentUrl),
+            })
+        );
+    }, []);
+
+    if (!isWindowOnPlayerPage) {
+        return null;
+    }
 
     if (userState.status === 'idle') {
         dispatch(fetchUserPreferences());

--- a/src/contentScript/component/store/appSlice.ts
+++ b/src/contentScript/component/store/appSlice.ts
@@ -1,0 +1,24 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+const initialState: {
+    isWindowOnPlayerPage: boolean;
+} = {
+    isWindowOnPlayerPage: false,
+};
+
+const appSlice = createSlice({
+    name: 'app',
+    initialState,
+    reducers: {
+        setIsWindowOnPlayerPage: (
+            state,
+            action: PayloadAction<{ isWindowOnPlayerPage: boolean }>
+        ) => {
+            state.isWindowOnPlayerPage = action.payload.isWindowOnPlayerPage;
+        },
+    },
+});
+
+export const { setIsWindowOnPlayerPage } = appSlice.actions;
+
+export default appSlice.reducer;

--- a/src/contentScript/component/store/store.ts
+++ b/src/contentScript/component/store/store.ts
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
+import appReducer from './appSlice';
 import subtitleReducer from './subtitleSlice';
 import userReducer from './userSlice';
 
 export const store = configureStore({
     reducer: {
+        app: appReducer,
         subtitle: subtitleReducer,
         user: userReducer,
     },

--- a/src/contentScript/contentScript.ts
+++ b/src/contentScript/contentScript.ts
@@ -1,4 +1,9 @@
 import './component/index.tsx';
+import { messageType } from '@/src/types/messages';
+import { store } from '@/src/contentScript/component/store/store';
+import { setIsWindowOnPlayerPage } from '@/src/contentScript/component/store/appSlice';
+
+console.log('ContentScript is loaded');
 
 // As content script is running in a different context,
 // we need to inject the pageScript into the DOM so that it can access the page's context.
@@ -14,12 +19,20 @@ window.addEventListener('load', () => {
 
 window.onmessage = (event) => {
     switch (event.data.type) {
-        case 'SUBTITLE/AVAILABLE_BCP47_LIST': {
+        case messageType.windowOnPlayerPage: {
+            store.dispatch(
+                setIsWindowOnPlayerPage({
+                    isWindowOnPlayerPage: event.data.payload,
+                })
+            );
+            return;
+        }
+        case messageType.availableBcp47List: {
             // TODO: This list will be stored in a Redux store later
             console.log('Received message from pageScript ', event.data);
             return;
         }
-        case 'SUBTITLE/RESPONSE': {
+        case messageType.subtitleResponse: {
             // TODO: This list will be stored in a Redux store later
             console.log(
                 'Received message from pageScript ',
@@ -27,7 +40,7 @@ window.onmessage = (event) => {
             );
             return;
         }
-        case 'SUBTITLE/FETCH_ERROR': {
+        case messageType.subtitleFetchError: {
             // TODO: Will let the user know that the subtitle fetch failed
             console.log('Received message from pageScript ', event.data);
             return;

--- a/src/pageScript/pageScript.ts
+++ b/src/pageScript/pageScript.ts
@@ -22,17 +22,29 @@ interface NetflixVideoPlayer {
     setTimedTextTrack: (textTrack: NetflixTimedTextTrack) => void;
 }
 
+const getNetflixVideoPlayer = (windowObject: Window & { netflix?: any }) => {
+    try {
+        const playerAppApi =
+            windowObject.netflix.appContext.state.playerApp.getAPI();
+        const playerSessionId =
+            playerAppApi.videoPlayer.getAllPlayerSessionIds()[0];
+        return playerAppApi.videoPlayer.getVideoPlayerBySessionId(
+            playerSessionId
+        ) as NetflixVideoPlayer;
+    } catch (_) {
+        return undefined;
+    }
+};
+
 const getNetflixVideoPlayerAsync = async (
     windowObject: Window & { netflix?: any }
 ) => {
-    await waitUntilAsync(() => windowObject.netflix);
-    const playerAppApi =
-        windowObject.netflix.appContext.state.playerApp.getAPI();
-    const playerSessionId =
-        playerAppApi.videoPlayer.getAllPlayerSessionIds()[0];
-    return playerAppApi.videoPlayer.getVideoPlayerBySessionId(
-        playerSessionId
-    ) as NetflixVideoPlayer;
+    await waitUntilAsync(
+        () => getNetflixVideoPlayer(windowObject) != undefined,
+        50,
+        10000
+    );
+    return getNetflixVideoPlayer(windowObject) as NetflixVideoPlayer;
 };
 
 const getTimedTextTrackListAsync = async (videoPlayer: NetflixVideoPlayer) => {

--- a/src/pageScript/pageScript.ts
+++ b/src/pageScript/pageScript.ts
@@ -9,6 +9,7 @@ import {
 import spyOnJsonParse from './spyOnJsonParse';
 import { getSubtitleDownloadUrls } from './subtitleDownloadUrlsStore';
 import parseXmlToSubtitles from './parseXmlToSubtitles';
+import spyOnPageUrl from '@/src/pageScript/spyOnPageUrl';
 
 // This code is injected into the page by contentScript.ts,
 // and it is executed in the page's context, unlike contentScript.ts and serviceWorker.ts.
@@ -137,6 +138,7 @@ const addSubtitleRequestMessageListener = (
 
 const main = async () => {
     spyOnJsonParse(window);
+    spyOnPageUrl(window);
 
     const netflixVideoPlayer = await getNetflixVideoPlayerAsync(window);
     const timedTextTrackList =

--- a/src/pageScript/spyOnJsonParse.ts
+++ b/src/pageScript/spyOnJsonParse.ts
@@ -11,7 +11,7 @@ const spyOnJsonParse = (windowObject: Window & { JSON: any }) => {
     windowObject.JSON.parse = (
         ...args: Parameters<typeof originalJsonParse>
     ) => {
-        const result = originalJsonParse(...args);
+        const result = originalJsonParse.apply(windowObject, args);
 
         if (result && result.result && result.result.movieId) {
             // Extract subtitle download URLs from the JSON response

--- a/src/pageScript/spyOnPageUrl.ts
+++ b/src/pageScript/spyOnPageUrl.ts
@@ -1,0 +1,50 @@
+import { WindowOnPlayerPage } from '@/src/types/messages';
+
+export const determineIfWindowOnPlayerPage = (url: string | URL) =>
+    typeof url === 'string'
+        ? url.includes('/watch/')
+        : url.href.includes('/watch/');
+
+const sendWindowOnPlayerPageMessage = (
+    url: string | URL | null | undefined
+) => {
+    if (url) {
+        window.postMessage({
+            type: 'APP/WINDOW_ON_PLAYER_PAGE',
+            payload: determineIfWindowOnPlayerPage(url),
+        } satisfies WindowOnPlayerPage);
+    }
+};
+const spyOnPageUrl = (windowObject: Window) => {
+    // addEventListener on popState
+    windowObject.addEventListener('popstate', () => {
+        const currentUrl = windowObject.location.href;
+        sendWindowOnPlayerPageMessage(currentUrl);
+    });
+
+    // Spy pushState
+    const originalPushState = windowObject.history.pushState;
+
+    windowObject.history.pushState = (
+        ...args: Parameters<typeof originalPushState>
+    ) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const [_, __, url] = args;
+        sendWindowOnPlayerPageMessage(url);
+        return originalPushState.apply(windowObject.history, args);
+    };
+
+    // Spy replaceState
+    const originalReplaceState = windowObject.history.replaceState;
+
+    windowObject.history.replaceState = (
+        ...args: Parameters<typeof originalReplaceState>
+    ) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const [_, __, url] = args;
+        sendWindowOnPlayerPageMessage(url);
+        return originalReplaceState.apply(windowObject.history, args);
+    };
+};
+
+export default spyOnPageUrl;

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -2,6 +2,7 @@ import { Subtitle } from './subtitle';
 import { UserPreferences } from './userPreferences';
 
 export const messageType = {
+    windowOnPlayerPage: 'APP/WINDOW_ON_PLAYER_PAGE',
     availableBcp47List: 'SUBTITLE/AVAILABLE_BCP47_LIST',
     subtitleRequest: 'SUBTITLE/REQUEST',
     subtitleResponse: 'SUBTITLE/RESPONSE',
@@ -13,6 +14,11 @@ export const messageType = {
 type MessageBase = {
     type: (typeof messageType)[keyof typeof messageType];
 };
+
+export interface WindowOnPlayerPage extends MessageBase {
+    type: 'APP/WINDOW_ON_PLAYER_PAGE';
+    payload: boolean;
+}
 
 export interface AvailableBcp47ListMessage extends MessageBase {
     type: 'SUBTITLE/AVAILABLE_BCP47_LIST';

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -8,7 +8,7 @@
     "content_scripts": [
         {
             "js": ["contentScript.js"],
-            "matches": ["*://*.netflix.com/watch/*"],
+            "matches": ["*://*.netflix.com/*"],
             "run_at": "document_end"
         }
     ],


### PR DESCRIPTION
#29 

This change is mainly for loading contentSciprt on "netflix.com", not "netflix.com/watch". PageScript detects whether the current window is on a video player page. The value is stored in a Redux store; the React app is displayed or hidden based on that value.

I have updated `getNetflixVideoPlayerAsync` function to wait till NetflixVideoPlayer is ready, not just `window.netflix` object.