### PR TITLE
#31 Ensure react app in content script is initialised after pageScript is ready. #32 Pause video when language preference modal opens.

### DIFF
--- a/src/contentScript/component/components/InitialLanguageSelectModal/index.tsx
+++ b/src/contentScript/component/components/InitialLanguageSelectModal/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
     Dialog,
     DialogContent,
@@ -18,6 +18,7 @@ import { useState } from 'react';
 import { setUserPreferences } from '@/src/contentScript/component/store/userSlice';
 import { setUserPreferences as setUserPreferencesInDB } from '@/src/serviceWorker/indexedDbOperations';
 import { UserPreferences } from '@/src/types/userPreferences';
+import { VideoPauseMessage, VideoPlayMessage } from '@/src/types/messages';
 
 const InitialLanguageSelectModal = () => {
     const dispatch = useDispatch<StoreDispatch>();
@@ -25,6 +26,17 @@ const InitialLanguageSelectModal = () => {
 
     const isInitialLanguageModalOpen =
         userState.status === 'success' && !userState.preferences?.studyLanguage;
+
+    useEffect(() => {
+        if (isInitialLanguageModalOpen) {
+            console.log('pausing video');
+            window.postMessage(
+                { type: 'VIDEO/PAUSE' } satisfies VideoPauseMessage,
+                '*'
+            );
+        }
+        return () => {};
+    }, [isInitialLanguageModalOpen]);
 
     const [studyLanguage, setStudyLanguage] = useState<string | undefined>();
     const [guideLanguage, setGuideLanguage] = useState<string | undefined>();
@@ -42,6 +54,11 @@ const InitialLanguageSelectModal = () => {
         dispatch(setUserPreferences(preferences));
 
         await setUserPreferencesInDB(preferences);
+
+        window.postMessage(
+            { type: 'VIDEO/PLAY' } satisfies VideoPlayMessage,
+            '*'
+        );
     };
 
     return (

--- a/src/contentScript/component/components/InitialLanguageSelectModal/index.tsx
+++ b/src/contentScript/component/components/InitialLanguageSelectModal/index.tsx
@@ -29,7 +29,6 @@ const InitialLanguageSelectModal = () => {
 
     useEffect(() => {
         if (isInitialLanguageModalOpen) {
-            console.log('pausing video');
             window.postMessage(
                 { type: 'VIDEO/PAUSE' } satisfies VideoPauseMessage,
                 '*'

--- a/src/contentScript/component/index.tsx
+++ b/src/contentScript/component/index.tsx
@@ -5,27 +5,29 @@ import { Provider } from 'react-redux';
 import { store } from './store/store';
 import './Index.css';
 
-const REACT_ROOT_ID = 'subtitle-extension-react-root';
+export const renderReactApp = () => {
+    const REACT_ROOT_ID = 'subtitle-extension-react-root';
 
-let rootElement = document.getElementById(REACT_ROOT_ID);
-if (!rootElement) {
-    rootElement = document.createElement('div');
-    rootElement.id = REACT_ROOT_ID;
-    document.body.appendChild(rootElement);
-}
+    let rootElement = document.getElementById(REACT_ROOT_ID);
+    if (!rootElement) {
+        rootElement = document.createElement('div');
+        rootElement.id = REACT_ROOT_ID;
+        document.body.appendChild(rootElement);
+    }
 
-const root = ReactDOM.createRoot(rootElement as HTMLElement);
+    const root = ReactDOM.createRoot(rootElement as HTMLElement);
 
-root.render(
-    <React.StrictMode>
-        <Provider store={store}>
-            <div
-                className={
-                    'fixed top-0 left-0 w-full h-full pointer-events-none'
-                }
-            >
-                <App />
-            </div>
-        </Provider>
-    </React.StrictMode>
-);
+    root.render(
+        <React.StrictMode>
+            <Provider store={store}>
+                <div
+                    className={
+                        'fixed top-0 left-0 w-full h-full pointer-events-none'
+                    }
+                >
+                    <App />
+                </div>
+            </Provider>
+        </React.StrictMode>
+    );
+};

--- a/src/contentScript/contentScript.ts
+++ b/src/contentScript/contentScript.ts
@@ -1,7 +1,7 @@
-import './component/index.tsx';
 import { messageType } from '@/src/types/messages';
 import { store } from '@/src/contentScript/component/store/store';
 import { setIsWindowOnPlayerPage } from '@/src/contentScript/component/store/appSlice';
+import { renderReactApp } from '@/src/contentScript/component';
 
 console.log('ContentScript is loaded');
 
@@ -19,6 +19,10 @@ window.addEventListener('load', () => {
 
 window.onmessage = (event) => {
     switch (event.data.type) {
+        case messageType.pageScriptIsReady: {
+            renderReactApp();
+            return;
+        }
         case messageType.windowOnPlayerPage: {
             store.dispatch(
                 setIsWindowOnPlayerPage({
@@ -27,7 +31,7 @@ window.onmessage = (event) => {
             );
             return;
         }
-        case messageType.availableBcp47List: {
+        case messageType.availableBcp47ListResponse: {
             // TODO: This list will be stored in a Redux store later
             console.log('Received message from pageScript ', event.data);
             return;

--- a/src/pageScript/pageScript.ts
+++ b/src/pageScript/pageScript.ts
@@ -30,7 +30,11 @@ const getNetflixVideoPlayer = (windowObject: Window & { netflix?: any }) => {
         const playerAppApi =
             windowObject.netflix.appContext.state.playerApp.getAPI();
         const playerSessionId =
-            playerAppApi.videoPlayer.getAllPlayerSessionIds()[0];
+            playerAppApi.videoPlayer.getAllPlayerSessionIds()[0] as string;
+        // Check if the playerSessionId is a watch session.
+        if (!playerSessionId.startsWith('watch')) {
+            return undefined;
+        }
         return playerAppApi.videoPlayer.getVideoPlayerBySessionId(
             playerSessionId
         ) as NetflixVideoPlayer;

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -9,6 +9,8 @@ export const messageType = {
     subtitleFetchError: 'SUBTITLE/FETCH_ERROR',
     getUserPreferences: 'USER_PREFERENCES/GET',
     setUserPreferences: 'USER_PREFERENCES/SET',
+    videoPause: 'VIDEO/PAUSE',
+    videoPlay: 'VIDEO/PLAY',
 } as const;
 
 type MessageBase = {
@@ -55,4 +57,11 @@ export interface SetUserPreferences extends MessageBase {
     payload: {
         userPreferences: UserPreferences;
     };
+}
+export interface VideoPauseMessage extends MessageBase {
+    type: 'VIDEO/PAUSE';
+}
+
+export interface VideoPlayMessage extends MessageBase {
+    type: 'VIDEO/PLAY';
 }

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -2,8 +2,10 @@ import { Subtitle } from './subtitle';
 import { UserPreferences } from './userPreferences';
 
 export const messageType = {
+    pageScriptIsReady: 'APP/PAGE_SCRIPT_IS_READY',
     windowOnPlayerPage: 'APP/WINDOW_ON_PLAYER_PAGE',
-    availableBcp47List: 'SUBTITLE/AVAILABLE_BCP47_LIST',
+    availableBcp47ListRequest: 'SUBTITLE/AVAILABLE_BCP47_LIST_REQUEST',
+    availableBcp47ListResponse: 'SUBTITLE/AVAILABLE_BCP47_LIST_RESPONSE',
     subtitleRequest: 'SUBTITLE/REQUEST',
     subtitleResponse: 'SUBTITLE/RESPONSE',
     subtitleFetchError: 'SUBTITLE/FETCH_ERROR',
@@ -17,13 +19,21 @@ type MessageBase = {
     type: (typeof messageType)[keyof typeof messageType];
 };
 
+export interface PageScriptIsReadyMessage extends MessageBase {
+    type: 'APP/PAGE_SCRIPT_IS_READY';
+}
+
 export interface WindowOnPlayerPage extends MessageBase {
     type: 'APP/WINDOW_ON_PLAYER_PAGE';
     payload: boolean;
 }
 
-export interface AvailableBcp47ListMessage extends MessageBase {
-    type: 'SUBTITLE/AVAILABLE_BCP47_LIST';
+export interface AvailableBcp47ListRequestMessage extends MessageBase {
+    type: 'SUBTITLE/AVAILABLE_BCP47_LIST_REQUEST';
+}
+
+export interface AvailableBcp47ListResponseMessage extends MessageBase {
+    type: 'SUBTITLE/AVAILABLE_BCP47_LIST_RESPONSE';
     payload: string[];
 }
 


### PR DESCRIPTION
#31 
To implement video playback control during the initial language selection, several foundational issues needed to be addressed. 
First, we discovered potential race conditions where the React app in the content script might attempt to access data before the pageScript was fully initialized. This led to a significant architectural improvement where we made pageScript reactive by introducing an AvailableBcp47ListRequestMessage system. 
Instead of pushing data immediately, pageScript now waits for explicit requests, ensuring more reliable data flow and preventing timing-related issues.

During this implementation, we also uncovered the need to properly handle Netflix's video player API complexity. Netflix's page can contain multiple video instances (main content, previews, modal previews) that share the same API methods for playback control and time information. To ensure our subtitle processing and playback control only affects the main video content, we enhanced the getNetflixVideoPlayer function to specifically filter for the main watch session, ignoring preview players.

#32 
These foundational improvements enabled us to successfully implement the video pause feature during language selection. The video now automatically pauses when the InitialLanguageSelectModal opens, allowing users to focus on their language selection without distractions, and resumes playback once they save their preferences.