### PR TITLE
#48 Implement switch mode for dictation and dual subtitle

### DIFF
--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as React from "react"
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     },
     "dependencies": {
         "@radix-ui/react-dialog": "^1.1.4",
+        "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-popover": "^1.1.4",
         "@radix-ui/react-slot": "^1.1.1",
+        "@radix-ui/react-switch": "^1.1.3",
         "@reduxjs/toolkit": "^2.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/src/contentScript/component/components/SubtitleDeck/DeckModeSwitch.tsx
+++ b/src/contentScript/component/components/SubtitleDeck/DeckModeSwitch.tsx
@@ -5,10 +5,10 @@ import { DeckMode } from '@/src/contentScript/component/components/SubtitleDeck/
 
 interface IProps {
     mode: DeckMode;
-    setModeChange: (mode: DeckMode) => void;
+    setDeckModeChange: (mode: DeckMode) => void;
 }
 
-const DeckModeSwitch: React.FC<IProps> = ({ mode, setModeChange }) => {
+const DeckModeSwitch: React.FC<IProps> = ({ mode, setDeckModeChange }) => {
     return (
         <div className="flex items-center space-x-2">
             <p className={'text-white text-sm font-medium'}>Dual Sub</p>
@@ -16,7 +16,7 @@ const DeckModeSwitch: React.FC<IProps> = ({ mode, setModeChange }) => {
                 id="dictation-mode"
                 checked={mode === 'dictation'}
                 onCheckedChange={(checked) =>
-                    setModeChange(checked ? 'dictation' : 'dualSub')
+                    setDeckModeChange(checked ? 'dictation' : 'dualSub')
                 }
             />
             <Label htmlFor="dictation-mode" className={'text-white'}>

--- a/src/contentScript/component/components/SubtitleDeck/DeckModeSwitch.tsx
+++ b/src/contentScript/component/components/SubtitleDeck/DeckModeSwitch.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { DeckMode } from '@/src/contentScript/component/components/SubtitleDeck/index';
+
+interface IProps {
+    mode: DeckMode;
+    setModeChange: (mode: DeckMode) => void;
+}
+
+const DeckModeSwitch: React.FC<IProps> = ({ mode, setModeChange }) => {
+    return (
+        <div className="flex items-center space-x-2">
+            <p className={'text-white text-sm font-medium'}>Dual Sub</p>
+            <Switch
+                id="dictation-mode"
+                checked={mode === 'dictation'}
+                onCheckedChange={(checked) =>
+                    setModeChange(checked ? 'dictation' : 'dualSub')
+                }
+            />
+            <Label htmlFor="dictation-mode" className={'text-white'}>
+                Dictation
+            </Label>
+        </div>
+    );
+};
+
+export default DeckModeSwitch;

--- a/src/contentScript/component/components/SubtitleDeck/SubtitleBar.tsx
+++ b/src/contentScript/component/components/SubtitleDeck/SubtitleBar.tsx
@@ -7,13 +7,17 @@ import { DeckMode } from '@/src/contentScript/component/components/SubtitleDeck/
 interface IProps {
     subtitle?: Subtitle;
     isUserAnswerChecking: boolean;
-    mode: DeckMode;
+    deckMode: DeckMode;
+    subType: 'study' | 'guide';
+    isAutoPause: boolean;
 }
 
 const SubtitleBar: React.FC<IProps> = ({
     subtitle,
     isUserAnswerChecking,
-    mode,
+    deckMode,
+    subType,
+    isAutoPause,
 }) => {
     const currentTime = useVideoCurrentTime(100);
 
@@ -25,10 +29,15 @@ const SubtitleBar: React.FC<IProps> = ({
           )
         : [];
 
+    const hasAutoPause =
+        subType === 'study' &&
+        (deckMode === 'dictation' || (deckMode === 'dualSub' && isAutoPause));
+
     useEffect(() => {
         // As this SubtitleBar is rendered every 100ms,
         // we need to check if the current time is within 0.1s of the end of the subtitle line
         if (
+            hasAutoPause &&
             currentTime &&
             currentSubtitleLines?.some(
                 (line) => line.endMs / 1000 - currentTime < 0.1
@@ -46,7 +55,7 @@ const SubtitleBar: React.FC<IProps> = ({
             {currentSubtitleLines?.map((line) => (
                 <p
                     className={`text-white text-base md:text-2xl ${
-                        mode === 'dictation' && !isUserAnswerChecking
+                        deckMode === 'dictation' && !isUserAnswerChecking
                             ? 'opacity-0'
                             : 'opacity-100'
                     }`}

--- a/src/contentScript/component/components/SubtitleDeck/SubtitleBar.tsx
+++ b/src/contentScript/component/components/SubtitleDeck/SubtitleBar.tsx
@@ -2,13 +2,19 @@ import React, { useEffect } from 'react';
 import { Subtitle } from '@/src/types/subtitle';
 import { VideoPauseMessage } from '@/src/types/messages';
 import useVideoCurrentTime from '@/src/contentScript/component/hooks/useVideoCurrentTime';
+import { DeckMode } from '@/src/contentScript/component/components/SubtitleDeck/index';
 
 interface IProps {
     subtitle?: Subtitle;
     isUserAnswerChecking: boolean;
+    mode: DeckMode;
 }
 
-const SubtitleBar: React.FC<IProps> = ({ subtitle, isUserAnswerChecking }) => {
+const SubtitleBar: React.FC<IProps> = ({
+    subtitle,
+    isUserAnswerChecking,
+    mode,
+}) => {
     const currentTime = useVideoCurrentTime(100);
 
     const currentSubtitleLines = currentTime
@@ -38,11 +44,15 @@ const SubtitleBar: React.FC<IProps> = ({ subtitle, isUserAnswerChecking }) => {
     return (
         <>
             {currentSubtitleLines?.map((line) => (
-                <text
-                    className={`text-white text-base md:text-2xl ${isUserAnswerChecking ? 'opacity-100' : 'opacity-0'}`}
+                <p
+                    className={`text-white text-base md:text-2xl ${
+                        mode === 'dictation' && !isUserAnswerChecking
+                            ? 'opacity-0'
+                            : 'opacity-100'
+                    }`}
                 >
                     {line.text}
-                </text>
+                </p>
             ))}
         </>
     );

--- a/src/contentScript/component/components/SubtitleDeck/index.tsx
+++ b/src/contentScript/component/components/SubtitleDeck/index.tsx
@@ -4,13 +4,17 @@ import { RootState } from '@/src/contentScript/component/store/store';
 import SubtitleBar from '@/src/contentScript/component/components/SubtitleDeck/SubtitleBar';
 import DictationTextInput from '@/src/contentScript/component/components/SubtitleDeck/DictationTextInput';
 import DeckModeSwitch from '@/src/contentScript/component/components/SubtitleDeck/DeckModeSwitch';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+
 export type DeckMode = 'dictation' | 'dualSub';
 const SubtitleDeck = () => {
     const subtitles = useSelector(
         (state: RootState) => state.subtitle.subtitles
     );
     const [isUserAnswerChecking, setIsUserAnswerChecking] = useState(false);
-    const [mode, setMode] = useState<DeckMode>('dictation');
+    const [deckMode, setDeckMode] = useState<DeckMode>('dictation');
+    const [isAutoPause, setIsAutoPause] = useState(false);
 
     console.log('All subtitles:', subtitles);
 
@@ -25,26 +29,43 @@ const SubtitleDeck = () => {
                     <SubtitleBar
                         subtitle={subtitles.study}
                         isUserAnswerChecking={isUserAnswerChecking}
-                        mode={mode}
+                        deckMode={deckMode}
+                        subType="study"
+                        isAutoPause={isAutoPause}
                     />
                 )}
                 {subtitles.guide && (
                     <SubtitleBar
                         subtitle={subtitles.guide}
                         isUserAnswerChecking={isUserAnswerChecking}
-                        mode={mode}
+                        deckMode={deckMode}
+                        subType="guide"
+                        isAutoPause={isAutoPause}
                     />
                 )}
 
-                {mode === 'dictation' && (
+                {deckMode === 'dictation' ? (
                     //Control video playback based on the study subtitle timestamps.
                     <DictationTextInput
                         subtitle={subtitles.study}
                         setIsUserAnswerChecking={setIsUserAnswerChecking}
                     />
+                ) : (
+                    <div className="flex items-center space-x-2">
+                        <Switch
+                            id="auto-pause"
+                            checked={isAutoPause}
+                            onCheckedChange={(checked) =>
+                                setIsAutoPause(checked)
+                            }
+                        />
+                        <Label htmlFor="auto-pause" className={'text-white'}>
+                            Auto Pause
+                        </Label>
+                    </div>
                 )}
 
-                <DeckModeSwitch mode={mode} setModeChange={setMode} />
+                <DeckModeSwitch mode={deckMode} setDeckModeChange={setDeckMode} />
             </div>
         </>
     );

--- a/src/contentScript/component/components/SubtitleDeck/index.tsx
+++ b/src/contentScript/component/components/SubtitleDeck/index.tsx
@@ -3,12 +3,14 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@/src/contentScript/component/store/store';
 import SubtitleBar from '@/src/contentScript/component/components/SubtitleDeck/SubtitleBar';
 import DictationTextInput from '@/src/contentScript/component/components/SubtitleDeck/DictationTextInput';
-
+import DeckModeSwitch from '@/src/contentScript/component/components/SubtitleDeck/DeckModeSwitch';
+export type DeckMode = 'dictation' | 'dualSub';
 const SubtitleDeck = () => {
     const subtitles = useSelector(
         (state: RootState) => state.subtitle.subtitles
     );
     const [isUserAnswerChecking, setIsUserAnswerChecking] = useState(false);
+    const [mode, setMode] = useState<DeckMode>('dictation');
 
     console.log('All subtitles:', subtitles);
 
@@ -16,20 +18,33 @@ const SubtitleDeck = () => {
         <>
             <div
                 className={
-                    'absolute bottom-44 w-full flex flex-col items-center justify-center space-y-2 pointer-events-auto'
+                    'absolute bottom-44 w-full flex flex-col items-center justify-center space-y-1.5 pointer-events-auto'
                 }
             >
-                {subtitles.study ? (
+                {subtitles.study && (
                     <SubtitleBar
                         subtitle={subtitles.study}
                         isUserAnswerChecking={isUserAnswerChecking}
+                        mode={mode}
                     />
-                ) : null}
-                {/*<SubtitleBar subtitle={subtitles.guide}/>*/}
-                <DictationTextInput
-                    subtitle={subtitles.study}
-                    setIsUserAnswerChecking={setIsUserAnswerChecking}
-                />
+                )}
+                {subtitles.guide && (
+                    <SubtitleBar
+                        subtitle={subtitles.guide}
+                        isUserAnswerChecking={isUserAnswerChecking}
+                        mode={mode}
+                    />
+                )}
+
+                {mode === 'dictation' && (
+                    //Control video playback based on the study subtitle timestamps.
+                    <DictationTextInput
+                        subtitle={subtitles.study}
+                        setIsUserAnswerChecking={setIsUserAnswerChecking}
+                    />
+                )}
+
+                <DeckModeSwitch mode={mode} setModeChange={setMode} />
             </div>
         </>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -398,6 +398,13 @@
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.0"
 
+"@radix-ui/react-label@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-2.1.2.tgz#994a5d815c2ff46e151410ae4e301f1b639f9971"
+  integrity sha512-zo1uGMTaNlHehDyFQcDZXRJhUPDuukcnHz0/jnrup0JA6qL+AFpAnty+7VKa9esuU5xTblAZzTGYJKSKaBxBhw==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.2"
+
 "@radix-ui/react-popover@^1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-popover/-/react-popover-1.1.4.tgz#d83104e5fb588870a673b55f3387da4844e5836e"
@@ -483,6 +490,13 @@
   dependencies:
     "@radix-ui/react-slot" "1.1.1"
 
+"@radix-ui/react-primitive@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz#ac8b7854d87b0d7af388d058268d9a7eb64ca8ef"
+  integrity sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==
+  dependencies:
+    "@radix-ui/react-slot" "1.1.2"
+
 "@radix-ui/react-slot@1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.2.tgz#a9ff4423eade67f501ffb32ec22064bc9d3099ab"
@@ -497,6 +511,26 @@
   integrity sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.1"
+
+"@radix-ui/react-slot@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.1.2.tgz#daffff7b2bfe99ade63b5168407680b93c00e1c6"
+  integrity sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.1"
+
+"@radix-ui/react-switch@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-switch/-/react-switch-1.1.3.tgz#cb6386909d1d3f65a2b81a3b15da8c91d18f49b0"
+  integrity sha512-1nc+vjEOQkJVsJtWPSiISGT6OKm4SiOdjMo+/icLxo2G4vxz1GntC5MzfL4v8ey9OEfw787QCD1y3mUv0NiFEQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.2"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+    "@radix-ui/react-use-previous" "1.1.0"
+    "@radix-ui/react-use-size" "1.1.0"
 
 "@radix-ui/react-use-callback-ref@1.0.1":
   version "1.0.1"
@@ -551,6 +585,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz#3c2c8ce04827b26a39e442ff4888d9212268bd27"
   integrity sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==
+
+"@radix-ui/react-use-previous@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz#d4dd37b05520f1d996a384eb469320c2ada8377c"
+  integrity sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==
 
 "@radix-ui/react-use-rect@1.1.0":
   version "1.1.0"


### PR DESCRIPTION
#48 

Initially considered using Redux for mode state management, but opted for local component state as it's sufficient for current needs. This can be easily migrated to Redux later if we need to persist mode preferences.

Choose to use a DeckMode type instead of a boolean state to make the code more maintainable and extensible for future modes.

DictationTextInput receives study subtitle data to control video navigation based on subtitle timestamps, not for rendering text.

I decided to use study subtitle timing for auto-pause control to avoid potential timing conflicts between study and guide subtitles.